### PR TITLE
testdata: use GLLVM as drop-in replacement for WLLVM

### DIFF
--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -19,14 +19,14 @@ test/%.ll: coreutils-$(VER)/src/%.bc
 
 # Extract LLVM IR bitcode from executables.
 coreutils-$(VER)/src/%.bc: coreutils-$(VER)/src/%
-	extract-bc $<
+	get-bc $<
 
 # Compile executables using WLLVM.
 .ONESHELL:
 coreutils-$(VER)/src/$(EXE): | coreutils-$(VER)
 	cd coreutils-$(VER)
 	export LLVM_COMPILER=clang
-	CC=wllvm ./configure
+	CC=gclang ./configure
 	make
 
 # Fetch source code.

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -21,11 +21,10 @@ test/%.ll: coreutils-$(VER)/src/%.bc
 coreutils-$(VER)/src/%.bc: coreutils-$(VER)/src/%
 	get-bc $<
 
-# Compile executables using WLLVM.
+# Compile executables using GLLVM.
 .ONESHELL:
 coreutils-$(VER)/src/$(EXE): | coreutils-$(VER)
 	cd coreutils-$(VER)
-	export LLVM_COMPILER=clang
 	CC=gclang ./configure
 	make
 

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,5 @@
+module github.com/llir/llvm/testdata
+
+go 1.14
+
+require github.com/SRI-CSL/gllvm v1.2.6

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,2 @@
+github.com/SRI-CSL/gllvm v1.2.6 h1:1IwK96SNtOtz+CiK+PFKodV66svtSvwyBPYWan87Qj8=
+github.com/SRI-CSL/gllvm v1.2.6/go.mod h1:v8ChJRFHrYBib7DZR6v/ZkNHO97WlSfYbq3nkNGtBQo=

--- a/sqlite/Makefile
+++ b/sqlite/Makefile
@@ -17,14 +17,13 @@ test/%.ll: sqlite-amalgamation-$(VER)/%.bc
 
 # Extract LLVM IR bitcode from executables.
 sqlite-amalgamation-$(VER)/%.bc: sqlite-amalgamation-$(VER)/%
-	extract-bc $<
+	get-bc $<
 
-# Compile executables using WLLVM.
+# Compile executables using GLLVM.
 .ONESHELL:
 sqlite-amalgamation-$(VER)/$(EXE): | sqlite-amalgamation-$(VER)
 	cd sqlite-amalgamation-$(VER)
-	export LLVM_COMPILER=clang
-	wllvm -g -o $(EXE) $(SRC_C) -lpthread -ldl
+	gclang -g -o $(EXE) $(SRC_C) -lpthread -ldl
 
 # Fetch source code.
 fetch: sqlite-amalgamation-$(VER)

--- a/tools/README.md
+++ b/tools/README.md
@@ -1,0 +1,11 @@
+# Tools
+
+## GLLVM
+
+To convert whole programs to LLVM bitcode, we rely on [gllvm](github.com/SRI-CSL/gllvm).
+
+### Installation
+
+```bash
+go get github.com/SRI-CSL/gllvm/cmd/...
+```

--- a/tools/README.md
+++ b/tools/README.md
@@ -2,7 +2,7 @@
 
 ## GLLVM
 
-To convert whole programs to LLVM bitcode, we rely on [gllvm](github.com/SRI-CSL/gllvm).
+To convert whole programs to LLVM bitcode, we rely on [gllvm](https://github.com/SRI-CSL/gllvm).
 
 ### Installation
 

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -1,0 +1,5 @@
+//+build tools
+
+package tools
+
+import _ "github.com/SRI-CSL/gllvm" // import for go.mod dependency


### PR DESCRIPTION
The main benefit of GLLVM is improved parallel build speed.

Fixes llir/llvm#139.